### PR TITLE
Implement basic "Dummy" authentication mechanism

### DIFF
--- a/src/credentials/mim-requester.ts
+++ b/src/credentials/mim-requester.ts
@@ -3,11 +3,13 @@ import _debug from "debug";
 import {
     IDiscoveredDevice,
     IDiscoveryMessage,
+    IDiscoveryNetwork,
     IDiscoveryNetworkFactory,
     INetworkConfig,
 } from "../discovery/model";
 import { DiscoveryVersions } from "../protocol";
 import { CancellableAsyncSink } from "../util/async";
+import { wakePortsByVersion } from "../waker/udp";
 import { ICredentialRequester, ICredentials } from "./model";
 
 export interface IEmulatorOptions {
@@ -44,9 +46,10 @@ export class MimCredentialRequester implements ICredentialRequester {
 
     public async requestForDevice(device: IDiscoveredDevice): Promise<ICredentials> {
         const sink = new CancellableAsyncSink<IDiscoveryMessage>();
-        const localBindPort = device.discoveryVersion === DiscoveryVersions.PS4
-            ? 987
-            : 987; // TODO ?
+        const localBindPort = wakePortsByVersion[device.discoveryVersion];
+        if (!localBindPort) {
+            throw new Error(`Unexpected discovery protocol: ${device.discoveryVersion}`);
+        }
 
         const hostType = device.discoveryVersion === DiscoveryVersions.PS4
             ? "PS4"
@@ -62,6 +65,20 @@ export class MimCredentialRequester implements ICredentialRequester {
 
         sink.onCancel = () => network.close();
 
+        return this.emulateUntilWoken(
+            sink,
+            network,
+            hostType,
+            localBindPort,
+        );
+    }
+
+    private async emulateUntilWoken(
+        incomingMessages: AsyncIterable<IDiscoveryMessage>,
+        network: IDiscoveryNetwork,
+        hostType: string,
+        localBindPort: number,
+    ) {
         const searchStatus = "HTTP/1.1 620 Server Standby";
         const searchResponse = {
             "host-id": this.emulatorOptions.hostId,
@@ -70,10 +87,11 @@ export class MimCredentialRequester implements ICredentialRequester {
             "host-request-port": localBindPort,
         };
 
-        for await (const message of sink) {
+        for await (const message of incomingMessages) {
             const { sender } = message;
             switch (message.type) {
                 case "SRCH":
+                    debug("respond to SRCH request from", sender);
                     await network.send(
                         sender.address,
                         sender.port,

--- a/src/credentials/mim-requester.ts
+++ b/src/credentials/mim-requester.ts
@@ -1,0 +1,62 @@
+import _debug from "debug";
+
+import {
+    IDiscoveredDevice,
+    IDiscoveryMessage,
+    IDiscoveryNetworkFactory,
+    INetworkConfig,
+} from "../discovery/model";
+import { DiscoveryVersions } from "../protocol";
+import { CancellableAsyncSink } from "../util/async";
+import { ICredentialRequester, ICredentials } from "./model";
+
+const debug = _debug("playground:credentials:mim");
+
+/**
+ * The MimCredentialRequester works by emulating a PlayStation device
+ * on the network that the PlayStation App can connect to. It then
+ * acts as a "man in the middle" to intercept the credentials that
+ * the app is passing.
+ */
+export class MimCredentialRequester implements ICredentialRequester {
+    constructor(
+        private readonly networkFactory: IDiscoveryNetworkFactory,
+        private readonly networkConfig: INetworkConfig,
+    ) {}
+
+    public async requestForDevice(device: IDiscoveredDevice): Promise<ICredentials> {
+        const sink = new CancellableAsyncSink<[IDiscoveryMessage, any]>();
+        const localBindPort = device.discoveryVersion === DiscoveryVersions.PS4
+            ? 987
+            : 987; // TODO ?
+
+        const network = this.networkFactory.createMessages({
+            ...this.networkConfig,
+            localBindPort,
+        }, (message, sender) => {
+            debug("received:", message, sender);
+            sink.write([message, sender]);
+        });
+
+        sink.onCancel = () => network.close();
+
+        for await (const [message, sender] of sink) {
+            switch (message.type) {
+                case "SRCH":
+                    // FIXME: respond with status message, etc.
+                    await network.send(sender.address, sender.port, "", {
+                    });
+                    break;
+
+                case "WAKEUP":
+                    debug("received WAKEUP from", sender);
+                    return message.data;
+
+                default:
+                    break; // nop
+            }
+        }
+
+        throw new Error("No credentials received");
+    }
+}

--- a/src/device.ts
+++ b/src/device.ts
@@ -28,7 +28,7 @@ export const Device = {
     ) {
         return new PendingDevice(
             `with address ${address}`,
-            device => device.address === address,
+            device => device.address.address === address,
             config,
             config,
         );

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -34,7 +34,7 @@ export class Discovery {
         debug("discover(", fullConfig, ")");
 
         const sink = new CancellableAsyncSink<IDiscoveredDevice>();
-        const network = this.networkFactory.create(networkConfig, device => {
+        const network = this.networkFactory.createDevices(networkConfig, device => {
             sink.write(device);
         });
 

--- a/src/discovery/composite.ts
+++ b/src/discovery/composite.ts
@@ -14,4 +14,18 @@ export class CompositeDiscoveryNetwork implements IDiscoveryNetwork {
     public async ping() {
         await Promise.all(this.delegates.map(d => d.ping()));
     }
+
+    public async send(
+        recipientAddress: string,
+        recipientPort: number,
+        type: string,
+        data?: Record<string, unknown>,
+    ): Promise<void> {
+        await Promise.all(this.delegates.map(d => d.send(
+            recipientAddress,
+            recipientPort,
+            type,
+            data,
+        )));
+    }
 }

--- a/src/discovery/messages.ts
+++ b/src/discovery/messages.ts
@@ -1,0 +1,51 @@
+import { DeviceStatus, DiscoveryMessageType } from "./model";
+
+interface IParsedMessage {
+    type: DiscoveryMessageType;
+    [key: string]: string;
+}
+
+const STATUS_CODE_STANDBY = "620";
+
+export function parseMessage(raw: Buffer): IParsedMessage {
+    const lines = raw.toString().split("\n");
+    if (!lines.length) {
+        throw new Error(`Invalid message: no lines: ${raw.toString()}`);
+    }
+
+    const result: IParsedMessage & Record<string, string> = {
+        type: DiscoveryMessageType.DEVICE,
+    };
+
+    const statusLine = lines[0];
+    if (statusLine.startsWith("HTTP")) {
+        // device response
+        const status = statusLine.substring(
+            statusLine.indexOf(" ") + 1,
+        );
+
+        result.statusLine = status;
+        const [code, message] = status.split(" ");
+        result.statusCode = code;
+        result.statusMessage = message;
+        result.status = code === STATUS_CODE_STANDBY
+            ? DeviceStatus.STANDBY
+            : DeviceStatus.AWAKE;
+    } else {
+        const method = statusLine.substring(0, statusLine.indexOf(" "));
+        if (undefined === (DiscoveryMessageType as any)[method]) {
+            throw new Error(`Unexpected discovery message: ${method}`);
+        }
+        result.type = method as DiscoveryMessageType;
+    }
+
+    for (let i = 1; i < lines.length; ++i) {
+        const line = lines[i];
+        const [key, value] = line.split(/:[ ]*/);
+        if (value) {
+            result[key.toLowerCase()] = value;
+        }
+    }
+
+    return result;
+}

--- a/src/discovery/model.ts
+++ b/src/discovery/model.ts
@@ -16,20 +16,37 @@ export interface INetworkConfig {
 }
 
 export enum DeviceStatus {
-    STANDBY,
-    AWAKE,
+    STANDBY = "STANDBY",
+    AWAKE = "AWAKE",
+}
+
+export interface IDeviceAddress {
+    address: string;
+    port: number;
+    family: "IPv4" | "IPv6";
+}
+
+export type DiscoveryKey =
+    "host-id"
+    | "host-type"
+    | "host-request-port"
+    | "host-name";
+
+export enum DiscoveryMessageType {
+    SRCH = "SRCH",
+    WAKEUP = "WAKEUP",
+    DEVICE = "DEVICE",
 }
 
 export interface IDiscoveryMessage {
-    type: "SRCH" | "WAKEUP" | "DEVICE";
-
-    // TODO:
-    data: any;
+    type: DiscoveryMessageType;
+    sender: IDeviceAddress;
+    version: DiscoveryVersion;
+    data: Record<DiscoveryKey | string, string>;
 }
 
 export interface IDiscoveredDevice {
-    address: string;
-    port: number;
+    address: IDeviceAddress;
 
     discoveryVersion: DiscoveryVersion;
     id: string;
@@ -37,10 +54,7 @@ export interface IDiscoveredDevice {
 }
 
 export type OnDeviceDiscoveredHandler = (device: IDiscoveredDevice) => void;
-export type OnDiscoveryMessageHandler = (
-    message: IDiscoveryMessage,
-    sender: { address: string, port: number },
-) => void;
+export type OnDiscoveryMessageHandler = (message: IDiscoveryMessage) => void;
 
 export interface IDiscoveryNetwork {
     close(): void;
@@ -52,7 +66,7 @@ export interface IDiscoveryNetwork {
         recipientAddress: string,
         recipientPort: number,
         type: string,
-        data?: Record<string, unknown>,
+        data?: Record<DiscoveryKey | string, unknown>,
     ): Promise<void>;
 }
 

--- a/src/discovery/model.ts
+++ b/src/discovery/model.ts
@@ -20,6 +20,13 @@ export enum DeviceStatus {
     AWAKE,
 }
 
+export interface IDiscoveryMessage {
+    type: "SRCH" | "WAKEUP" | "DEVICE";
+
+    // TODO:
+    data: any;
+}
+
 export interface IDiscoveredDevice {
     address: string;
     port: number;
@@ -30,16 +37,32 @@ export interface IDiscoveredDevice {
 }
 
 export type OnDeviceDiscoveredHandler = (device: IDiscoveredDevice) => void;
+export type OnDiscoveryMessageHandler = (
+    message: IDiscoveryMessage,
+    sender: { address: string, port: number },
+) => void;
 
 export interface IDiscoveryNetwork {
     close(): void;
 
     /** Request devices on the network to identify themselves */
     ping(): Promise<void>;
+
+    send(
+        recipientAddress: string,
+        recipientPort: number,
+        type: string,
+        data?: Record<string, unknown>,
+    ): Promise<void>;
 }
 
 export interface IDiscoveryNetworkFactory {
-    create(
+    createMessages(
+        config: INetworkConfig,
+        onMessage: OnDiscoveryMessageHandler,
+    ): IDiscoveryNetwork;
+
+    createDevices(
         config: INetworkConfig,
         onDevice: OnDeviceDiscoveredHandler,
     ): IDiscoveryNetwork;

--- a/src/discovery/standard.ts
+++ b/src/discovery/standard.ts
@@ -6,6 +6,7 @@ import {
     IDiscoveryNetworkFactory,
     INetworkConfig,
     OnDeviceDiscoveredHandler,
+    OnDiscoveryMessageHandler,
 } from "./model";
 import { UdpDiscoveryNetworkFactory } from "./udp";
 
@@ -15,12 +16,21 @@ const standardFactories = [
 ];
 
 export const StandardDiscoveryNetworkFactory: IDiscoveryNetworkFactory = {
-    create(
+    createDevices(
         config: INetworkConfig,
         onDevice: OnDeviceDiscoveredHandler,
     ): IDiscoveryNetwork {
         return new CompositeDiscoveryNetwork(
-            standardFactories.map(factory => factory.create(config, onDevice)),
+            standardFactories.map(factory => factory.createDevices(config, onDevice)),
+        );
+    },
+
+    createMessages(
+        config: INetworkConfig,
+        onMessage: OnDiscoveryMessageHandler,
+    ): IDiscoveryNetwork {
+        return new CompositeDiscoveryNetwork(
+            standardFactories.map(factory => factory.createMessages(config, onMessage)),
         );
     },
 };

--- a/src/socket/tcp.ts
+++ b/src/socket/tcp.ts
@@ -47,7 +47,7 @@ export class TcpDeviceSocket implements IDeviceSocket {
         return new Promise<TcpDeviceSocket>((resolve, reject) => {
             const socket = net.createConnection({
                 port,
-                host: device.address,
+                host: device.address.address,
                 timeout: config.connectTimeoutMillis,
             });
             socket.once("connect", () => {

--- a/src/waker/udp.ts
+++ b/src/waker/udp.ts
@@ -28,7 +28,8 @@ export class UdpWakerNetwork implements IWakerNetwork {
         }
 
         return new Promise<void>((resolve, reject) => {
-            socket.send(message, device.port, device.address, err => {
+            const { port, address } = device.address;
+            socket.send(message, port, address, err => {
                 if (err) reject(err);
                 else resolve();
             });

--- a/src/waker/udp.ts
+++ b/src/waker/udp.ts
@@ -4,7 +4,7 @@ import { IDiscoveredDevice, INetworkConfig } from "../discovery/model";
 import { DiscoveryVersions } from "../protocol";
 import { IWakerNetwork, IWakerNetworkFactory } from "./model";
 
-const wakePortsByVersion = {
+export const wakePortsByVersion = {
     [DiscoveryVersions.PS4]: 987,
     [DiscoveryVersions.PS5]: 9302,
 };

--- a/test/discovery-test.ts
+++ b/test/discovery-test.ts
@@ -7,6 +7,17 @@ import { IDiscoveryNetwork } from "../src/discovery/model";
 chai.should();
 
 class MockNetwork implements IDiscoveryNetwork {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    public async send(
+        recipientAddress: string,
+        recipientPort: number,
+        type: string,
+        data?: Record<string, unknown>,
+    ): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
     public close() {
         // nop
     }
@@ -29,7 +40,10 @@ describe("Discovery", () => {
     beforeEach(() => {
         clock = FakeTimers.install();
         discovery = new Discovery({}, {
-            create() {
+            createDevices() {
+                return /* lastNetwork = */ new MockNetwork();
+            },
+            createMessages() {
                 return /* lastNetwork = */ new MockNetwork();
             },
         });

--- a/test/discovery/messages-test.ts
+++ b/test/discovery/messages-test.ts
@@ -1,0 +1,46 @@
+import * as chai from "chai";
+import chaiSubset from "chai-subset";
+
+import { parseMessage } from "../../src/discovery/messages";
+import { DeviceStatus } from "../../src/discovery/model";
+
+chai.use(chaiSubset);
+chai.should();
+
+describe("discovery.parseMessage", () => {
+    it("handles device announcements", () => {
+        const m = Buffer.from(`
+HTTP/1.1 620 Server Standby
+        `.trim());
+
+        parseMessage(m).should.containSubset({
+            type: "DEVICE",
+            status: DeviceStatus.STANDBY,
+        });
+    });
+
+    it("handles requests", () => {
+        const m = Buffer.from(`
+SRCH * HTTP/1.1
+        `.trim());
+
+        parseMessage(m).should.containSubset({
+            type: "SRCH",
+        });
+    });
+
+    it("includes and normalizes extra 'header' data", () => {
+        const m = Buffer.from(`
+WAKEUP * HTTP/1.1
+Host-Id: serenity
+Auth-Type: C
+        `.trim());
+
+        parseMessage(m).should.containSubset({
+            type: "WAKEUP",
+
+            "auth-type": "C",
+            "host-id": "serenity",
+        });
+    });
+});


### PR DESCRIPTION
Not accessible anywhere yet since it still probably belongs exclusively
in a CLI flow, but this PR implements the MimCredentialRequester,
porting the old "Dummy" mechanism from ps4-waker as an implementation of
the ICredentialRequester interface.

An actual usage should probably wrap this class with a
"RootManagingCredentialRequester" (or something) that ensures any root
priveleges the process has are relinquished; requesting those priveleges
is done in ps4-waker by re-spawning the proc, which is probably not reasonably accomplishable within the API...

- Create initial port of the old "Dummy" tool for auth
- Actually parse discovery messages; complete MimRequester
- Clean up compile errors
- Fix compile errors caused by refactor
- Clean up MimCredentialRequester somewhat
