### PR TITLE
Prepare initial CLI support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,7 +387,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -639,6 +638,45 @@
         "readdirp": "~3.5.0"
       }
     },
+    "clime": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/clime/-/clime-0.5.14.tgz",
+      "integrity": "sha512-+q7UDQ+EcruHtZRtd2QVs+t/jf9MpuOyhHbuHcYWvjX8jdly6AU7z3/7MiI0Kj0hzueIEX9JM7vPnkzBrG082Q==",
+      "requires": {
+        "chalk": "^2.1.0",
+        "extendable-error": "^0.1.5",
+        "hyphenate": "^0.2.1",
+        "parse-messy-time": "^2.1.0",
+        "reflect-metadata": "^0.1.10",
+        "strip-ansi": "^4.0.0",
+        "villa": "^0.2.11"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -694,7 +732,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -702,8 +739,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -860,8 +896,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.16.0",
@@ -1238,6 +1273,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1462,8 +1502,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1482,6 +1521,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
+    },
+    "hyphenate": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/hyphenate/-/hyphenate-0.2.5.tgz",
+      "integrity": "sha512-mSY0+dVLWFq7iIUgiID3EWo5S8rLnZa595mcuWiN8di91n6eL+WS8HKmcpiZZIX7iElri0a/2hOYpwzldsY4gQ=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -2086,6 +2130,11 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-messy-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-messy-time/-/parse-messy-time-2.1.0.tgz",
+      "integrity": "sha1-ehTOehxPZbXt4kM5nMBW2GvVetU="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2227,6 +2276,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -2521,7 +2575,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -2657,6 +2710,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "villa": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/villa/-/villa-0.2.11.tgz",
+      "integrity": "sha1-qZocCsAQJbcxG7VQwfp/jmVwaSo="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "wol",
     "remote"
   ],
+  "bin": {
+    "playground": "./dist/cli/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dhleong/playground.git"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
+    "clime": "^0.5.14",
     "debug": "^4.2.0",
     "fs-extra": "^9.0.1",
     "ix": "^4.0.0",

--- a/src/cli/commands/browse.ts
+++ b/src/cli/commands/browse.ts
@@ -1,0 +1,26 @@
+import {
+    Command,
+    command,
+    metadata,
+} from "clime";
+
+import { DiscoveryOptions } from "../options";
+import { Discovery } from "../../discovery";
+
+@command({
+    description: "Browse for device on the network, printing information about each one",
+})
+export default class extends Command {
+    @metadata
+    public async execute(
+        options: DiscoveryOptions,
+    ) {
+        const discovery = new Discovery(
+            options.discoveryConfig,
+        );
+
+        for await (const device of discovery.discover()) {
+            options.logResult(device);
+        }
+    }
+}

--- a/src/cli/commands/browse.ts
+++ b/src/cli/commands/browse.ts
@@ -8,7 +8,7 @@ import { DiscoveryOptions } from "../options";
 import { Discovery } from "../../discovery";
 
 @command({
-    description: "Browse for device on the network, printing information about each one",
+    brief: "Browse for device on the network",
 })
 export default class extends Command {
     @metadata

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,0 +1,69 @@
+import {
+    Command,
+    command,
+    metadata,
+    Printable,
+} from "clime";
+
+import { DeviceOptions } from "../options";
+import { DeviceStatus } from "../../discovery/model";
+
+class DeviceStatusSignal extends Error implements Printable {
+    constructor(
+        private readonly status: DeviceStatus | null,
+    ) {
+        super();
+    }
+
+    public print() {
+        switch (this.status) {
+            case null:
+                process.exit(2);
+                break;
+
+            case DeviceStatus.AWAKE:
+                process.exit(0);
+                break;
+
+            case DeviceStatus.STANDBY:
+                process.exit(1);
+                break;
+        }
+    }
+}
+
+@command({
+    brief: "Detect a device and its state on the network",
+    description: `
+Detect a device and its state on the network. If found, information
+about it will be printed to the console.
+
+In addition, the status of the device can be determined by the exit code
+of this process:
+
+    0 - The device was found and is awake
+    1 - The device was found and it is in standby
+    2 - The device was not found
+    `.trim(),
+})
+export default class extends Command {
+    @metadata
+    public async execute(
+        options: DeviceOptions,
+    ) {
+        try {
+            const device = await options.findDevice();
+            const info = await device.discover();
+            options.logResult(info);
+            throw new DeviceStatusSignal(info.status);
+        } catch (e) {
+            if (e instanceof DeviceStatusSignal) {
+                throw e;
+            }
+
+            options.logError(e);
+
+            throw new DeviceStatusSignal(null);
+        }
+    }
+}

--- a/src/cli/commands/send-keys.ts
+++ b/src/cli/commands/send-keys.ts
@@ -36,7 +36,18 @@ export function parseKeys(keys: string[]): KeyPress[] {
 }
 
 @command({
-    description: "Send a sequence of keys",
+    brief: "Send a sequence of keys",
+    description: `
+Send a sequence of keys to the device. Valid keys are:
+
+    up, down, left, right, enter, back, option, ps
+
+You cannot send the actual x, square, etc. buttons. Each provided key
+will be sent sequentially.
+
+In addition, a key name may be followed by a colon and a duration in
+milliseconds to hold that key, eg: playground send-keys ps:1000
+    `.trim(),
 })
 export default class extends Command {
     /* eslint-disable @typescript-eslint/indent */

--- a/src/cli/commands/send-keys.ts
+++ b/src/cli/commands/send-keys.ts
@@ -1,0 +1,61 @@
+import { Command, command, params } from "clime";
+import { KeyPress } from "../../socket/proc/remote-control";
+import { RemoteOperation } from "../../socket/remote";
+
+import { DeviceOptions } from "../options";
+
+const nameToOp = Object.keys(RemoteOperation).reduce((m, name) => {
+    // eslint-disable-next-line no-param-reassign
+    m[name.toLowerCase()] = (RemoteOperation as any)[name] as RemoteOperation;
+    return m;
+}, {} as {[key: string]: RemoteOperation});
+
+/** Public for testing */
+export function parseKeys(keys: string[]): KeyPress[] {
+    return keys.map(raw => {
+        const [keyName, holdTimeString] = raw.split(":");
+        const key = nameToOp[keyName.toLowerCase()];
+        if (!key) {
+            throw new Error(`Invalid key name: ${key}`);
+        }
+
+        if (holdTimeString) {
+            const holdTimeMillis = parseInt(holdTimeString, 10);
+            if (holdTimeMillis < 0) {
+                throw new Error(`Hold time must not be negative: ${holdTimeMillis}`);
+            }
+
+            return {
+                key,
+                holdTimeMillis,
+            };
+        }
+
+        return { key };
+    });
+}
+
+@command({
+    description: "Send a sequence of keys",
+})
+export default class extends Command {
+    /* eslint-disable @typescript-eslint/indent */
+    public async execute(
+        @params({
+            description: "The keys to send",
+            required: true,
+            type: String,
+        })
+        keys: string[],
+        deviceSpec: DeviceOptions,
+    ) {
+        const keyPresses = parseKeys(keys);
+        const device = await deviceSpec.findDevice();
+        const connection = await device.openConnection();
+        try {
+            await connection.sendKeys(keyPresses);
+        } finally {
+            await connection.close();
+        }
+    }
+}

--- a/src/cli/commands/standby.ts
+++ b/src/cli/commands/standby.ts
@@ -1,0 +1,21 @@
+import { Command, command, metadata } from "clime";
+
+import { DeviceOptions } from "../options";
+
+@command({
+    description: "Request the device enter standby/rest mode",
+})
+export default class extends Command {
+    @metadata
+    public async execute(
+        deviceSpec: DeviceOptions,
+    ) {
+        const device = await deviceSpec.findDevice();
+        const connection = await device.openConnection();
+        try {
+            await connection.standby();
+        } finally {
+            await connection.close();
+        }
+    }
+}

--- a/src/cli/commands/start-id.ts
+++ b/src/cli/commands/start-id.ts
@@ -1,0 +1,25 @@
+import { Command, command, param } from "clime";
+
+import { DeviceOptions } from "../options";
+
+@command({
+    description: "Start an app or game by its Title ID",
+})
+export default class extends Command {
+    /* eslint-disable @typescript-eslint/indent */
+    public async execute(
+        @param({
+            required: true,
+        })
+        titleId: string,
+        deviceSpec: DeviceOptions,
+    ) {
+        const device = await deviceSpec.findDevice();
+        const connection = await device.openConnection();
+        try {
+            await connection.startTitleId(titleId);
+        } finally {
+            await connection.close();
+        }
+    }
+}

--- a/src/cli/commands/wake.ts
+++ b/src/cli/commands/wake.ts
@@ -1,0 +1,16 @@
+import { Command, command, metadata } from "clime";
+
+import { DeviceOptions } from "../options";
+
+@command({
+    description: "Wake up a device",
+})
+export default class extends Command {
+    @metadata
+    public async execute(
+        deviceSpec: DeviceOptions,
+    ) {
+        const device = await deviceSpec.findDevice();
+        await device.wake();
+    }
+}

--- a/src/cli/commands/wake.ts
+++ b/src/cli/commands/wake.ts
@@ -3,7 +3,7 @@ import { Command, command, metadata } from "clime";
 import { DeviceOptions } from "../options";
 
 @command({
-    description: "Wake up a device",
+    description: "Wake up the device",
 })
 export default class extends Command {
     @metadata

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import path from "path";
+import { CLI, Shim } from "clime";
+
+// The second parameter is the path to folder that contains command modules.
+const cli = new CLI("playground", path.join(__dirname, "commands"));
+
+if (process.argv[0].endsWith("ts-node")) {
+    CLI.commandModuleExtension = ".ts";
+}
+
+// Clime in its core provides an object-based command-line infrastructure.
+// To have it work as a common CLI, a shim needs to be applied:
+const shim = new Shim(cli);
+shim.execute(process.argv);

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -39,18 +39,26 @@ export class LoggingOptions extends Options {
     }
 }
 
-export class DeviceOptions extends LoggingOptions {
+export class DiscoveryOptions extends LoggingOptions {
+    @option({
+        name: "timeout",
+        description: "How long to look for device(s) (milliseconds)",
+    })
+    public deviceTimeout?: number;
+
+    public get discoveryConfig(): Partial<IDiscoveryConfig> {
+        return {
+            timeoutMillis: this.deviceTimeout,
+        };
+    }
+}
+
+export class DeviceOptions extends DiscoveryOptions {
     @option({
         name: "ip",
         description: "Select a specific device by IP",
     })
     public deviceIp?: string;
-
-    @option({
-        name: "timeout",
-        description: "How long to look for the device (milliseconds)",
-    })
-    public deviceTimeout?: number;
 
     public async findDevice() {
         this.configureLogging();
@@ -59,10 +67,6 @@ export class DeviceOptions extends LoggingOptions {
 
         const networkConfig: INetworkConfig = {
             // TODO
-        };
-
-        const discoveryConfig: Partial<IDiscoveryConfig> = {
-            timeoutMillis: this.deviceTimeout,
         };
 
         const networkFactory = StandardDiscoveryNetworkFactory;
@@ -77,7 +81,7 @@ export class DeviceOptions extends LoggingOptions {
             description,
             predicate,
             networkConfig,
-            discoveryConfig,
+            this.discoveryConfig,
             networkFactory,
             credentials,
         );

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,0 +1,53 @@
+import {
+    Options,
+    option,
+} from "clime";
+import { CredentialManager } from "../credentials";
+
+import { PendingDevice } from "../device/pending";
+import { IDiscoveredDevice } from "../discovery/model";
+import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
+
+export class LoggingOptions extends Options {
+    @option({
+        flag: "v",
+        description: "Output verbose logging",
+        toggle: true,
+    })
+    public verbose = false;
+}
+
+export class DeviceOptions extends LoggingOptions {
+    @option({
+        name: "ip",
+        description: "Select a specific device by IP",
+    })
+    public deviceIp?: string;
+
+    public async findDevice() {
+        let description = "any device";
+        let predicate: (device: IDiscoveredDevice) => boolean = () => true;
+
+        if (this.deviceIp) {
+            description = `device at ${this.deviceIp}`;
+            predicate = device => device.address.address === this.deviceIp;
+        }
+
+        // TODO other selection mechanisms, network options, etc.
+
+        // TODO dummy support
+        const credentials = new CredentialManager();
+
+        const device = new PendingDevice(
+            description,
+            predicate,
+            {}, {},
+            StandardDiscoveryNetworkFactory,
+            credentials,
+        );
+        await device.discover();
+
+        // if we got here, the device was found!
+        return device;
+    }
+}

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -8,6 +8,7 @@ import { CredentialManager } from "../credentials";
 import { PendingDevice } from "../device/pending";
 import { IDiscoveredDevice, IDiscoveryConfig, INetworkConfig } from "../discovery/model";
 import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
+import { MimCredentialRequester } from "../credentials/mim-requester";
 
 export class LoggingOptions extends Options {
     @option({
@@ -50,15 +51,20 @@ export class DeviceOptions extends LoggingOptions {
             timeoutMillis: this.deviceTimeout,
         };
 
-        // TODO dummy support
-        const credentials = new CredentialManager();
+        const networkFactory = StandardDiscoveryNetworkFactory;
+        const credentials = new CredentialManager(
+            new MimCredentialRequester(
+                networkFactory,
+                networkConfig,
+            ),
+        );
 
         const device = new PendingDevice(
             description,
             predicate,
             networkConfig,
             discoveryConfig,
-            StandardDiscoveryNetworkFactory,
+            networkFactory,
             credentials,
         );
         await device.discover();

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -11,12 +11,26 @@ import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
 import { MimCredentialRequester } from "../credentials/mim-requester";
 
 export class LoggingOptions extends Options {
+    /* eslint-disable no-console */
+
     @option({
         name: "debug",
         description: "Enable debug logging",
         toggle: true,
     })
     public enableDebug = false;
+
+    public logError(error: any) {
+        console.error(error);
+    }
+
+    public logResult(result: any) {
+        if (typeof result === "string") {
+            console.log(result);
+        } else {
+            console.log(JSON.stringify(result, null, 2));
+        }
+    }
 
     public async configureLogging() {
         if (this.enableDebug) {

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -34,7 +34,7 @@ export class DeviceOptions extends LoggingOptions {
 
     @option({
         name: "timeout",
-        description: "How long to wait before deciding the device cannot be found (milliseconds)",
+        description: "How long to look for the device (milliseconds)",
     })
     public deviceTimeout?: number;
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -40,15 +40,7 @@ export class DeviceOptions extends LoggingOptions {
     public async findDevice() {
         this.configureLogging();
 
-        let description = "any device";
-        let predicate: (device: IDiscoveredDevice) => boolean = () => true;
-
-        if (this.deviceIp) {
-            description = `device at ${this.deviceIp}`;
-            predicate = device => device.address.address === this.deviceIp;
-        }
-
-        // TODO other selection mechanisms
+        const { description, predicate } = this.configurePending();
 
         const networkConfig: INetworkConfig = {
             // TODO
@@ -73,5 +65,18 @@ export class DeviceOptions extends LoggingOptions {
 
         // if we got here, the device was found!
         return device;
+    }
+
+    private configurePending() {
+        let description = "any device";
+        let predicate: (device: IDiscoveredDevice) => boolean = () => true;
+
+        if (this.deviceIp) {
+            description = `device at ${this.deviceIp}`;
+            predicate = device => device.address.address === this.deviceIp;
+        }
+
+        // TODO other selection mechanisms
+        return { description, predicate };
     }
 }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -8,8 +8,8 @@ import { IDiscoveredDevice } from "./discovery/model";
 
 export class CredentialManager {
     constructor(
-        private readonly storage: ICredentialStorage = new DiskCredentialsStorage(),
         private readonly requester: ICredentialRequester = RejectingCredentialRequester,
+        private readonly storage: ICredentialStorage = new DiskCredentialsStorage(),
     ) {}
 
     public async getForDevice(device: IDiscoveredDevice) {

--- a/src/device/pending.ts
+++ b/src/device/pending.ts
@@ -23,6 +23,7 @@ export class PendingDevice implements IDevice {
         private readonly discoveryConfig: Partial<IDiscoveryConfig> = {},
         private readonly discoveryFactory: IDiscoveryNetworkFactory =
         StandardDiscoveryNetworkFactory,
+        private readonly credentials: CredentialManager = new CredentialManager(),
     ) {}
 
     public async discover(config?: INetworkConfig) {
@@ -54,7 +55,7 @@ export class PendingDevice implements IDevice {
             if (this.predicate(device)) {
                 const newDelegate = new ResolvedDevice(
                     new SimpleWakerFactory({
-                        credentials: new CredentialManager(),
+                        credentials: this.credentials,
                         discoveryConfig: this.discoveryConfig,
                         networkFactory: new UdpWakerNetworkFactory(),
                         discoveryFactory: StandardDiscoveryNetworkFactory,

--- a/test/cli/commands/send-keys-test.ts
+++ b/test/cli/commands/send-keys-test.ts
@@ -1,0 +1,38 @@
+import * as chai from "chai";
+import { expect } from "chai";
+
+import { parseKeys } from "../../../src/cli/commands/send-keys";
+import { RemoteOperation } from "../../../src/socket/remote";
+
+chai.should();
+
+describe("SendKeysCommand", () => {
+    it("parses simple key names into ops", () => {
+        parseKeys(["enter", "ps", "up"]).should.deep.equal([
+            { key: RemoteOperation.Enter },
+            { key: RemoteOperation.PS },
+            { key: RemoteOperation.Up },
+        ]);
+    });
+
+    it("ignores case on key name", () => {
+        parseKeys(["EnTeR", "PS", "uP"]).should.deep.equal([
+            { key: RemoteOperation.Enter },
+            { key: RemoteOperation.PS },
+            { key: RemoteOperation.Up },
+        ]);
+    });
+
+    it("parses key names with hold times", () => {
+        parseKeys(["enter:42", "ps:9001"]).should.deep.equal([
+            { key: RemoteOperation.Enter, holdTimeMillis: 42 },
+            { key: RemoteOperation.PS, holdTimeMillis: 9001 },
+        ]);
+    });
+
+    it("rejects invalid times", () => {
+        expect(() => {
+            parseKeys(["enter:-42"]);
+        }).to.throw();
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,8 +54,8 @@
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "typeRoots": [
       "./node_modules/@types",
       "./src/@types"


### PR DESCRIPTION
Complete and proper support for using the `MimCredentialsRequester` to come in the future when I can properly test it.

- Sketch out the beginnings of a CLI
- Add --debug flag to conveniently enable all debug logs
- Move selection config to its own method
- Prepare initial support for auth via CLI
- Fill out a few CLI commands
- Implement send-keys command
- Add a description of how to use keys to the send-keys command
- Simplify the --timeout description
- Implement the `check` command
- Add a basic browse command
- Simplify description of browse command
- Add `bin` entry to package.json
