### PR TITLE
Add -c flag for specifying the credentials file to use

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -9,6 +9,7 @@ import { PendingDevice } from "../device/pending";
 import { IDiscoveredDevice, IDiscoveryConfig, INetworkConfig } from "../discovery/model";
 import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
 import { MimCredentialRequester } from "../credentials/mim-requester";
+import { DiskCredentialsStorage } from "../credentials/disk-storage";
 
 export class LoggingOptions extends Options {
     /* eslint-disable no-console */
@@ -60,6 +61,14 @@ export class DeviceOptions extends DiscoveryOptions {
     })
     public deviceIp?: string;
 
+    @option({
+        name: "credentials",
+        flag: "c",
+        placeholder: "path",
+        description: "Path to a file for storing credentials",
+    })
+    public credentialsPath?: string;
+
     public async findDevice() {
         this.configureLogging();
 
@@ -74,6 +83,9 @@ export class DeviceOptions extends DiscoveryOptions {
             new MimCredentialRequester(
                 networkFactory,
                 networkConfig,
+            ),
+            new DiskCredentialsStorage(
+                this.credentialsPath,
             ),
         );
 

--- a/src/credentials/disk-storage.ts
+++ b/src/credentials/disk-storage.ts
@@ -9,9 +9,13 @@ export function determineDefaultFile() {
 }
 
 export class DiskCredentialsStorage implements ICredentialStorage {
+    public readonly filePath: string;
+
     constructor(
-        public readonly filePath: string = determineDefaultFile(),
-    ) {}
+        filePath?: string,
+    ) {
+        this.filePath = filePath ?? determineDefaultFile();
+    }
 
     public async read(deviceId: string): Promise<ICredentials | null> {
         const json = await this.readCredentialsMap();


### PR DESCRIPTION
We now support storing more than one credential per file, for controlling more than one device at a time, but some setups may want to support logging in with different users, and that still requires separate credential files—or, well, it requires *some* flag, and separating per-user credentials by file seems the cleanest to me.
