### PR TITLE
Add passcode support to CLI + utils for parsing key-based codes

### DIFF
--- a/src/cli/commands/osk-submit.ts
+++ b/src/cli/commands/osk-submit.ts
@@ -20,7 +20,7 @@ export default class extends Command {
         deviceSpec: DeviceOptions,
     ) {
         const device = await deviceSpec.findDevice();
-        const connection = await device.openConnection();
+        const connection = await device.openConnection(deviceSpec.connectionConfig);
         try {
             const osk = await connection.openKeyboard();
 

--- a/src/cli/commands/send-keys.ts
+++ b/src/cli/commands/send-keys.ts
@@ -62,7 +62,7 @@ export default class extends Command {
     ) {
         const keyPresses = parseKeys(keys);
         const device = await deviceSpec.findDevice();
-        const connection = await device.openConnection();
+        const connection = await device.openConnection(deviceSpec.connectionConfig);
         try {
             await connection.sendKeys(keyPresses);
         } finally {

--- a/src/cli/commands/standby.ts
+++ b/src/cli/commands/standby.ts
@@ -18,7 +18,7 @@ export default class extends Command {
             return;
         }
 
-        const connection = await device.openConnection();
+        const connection = await device.openConnection(deviceSpec.connectionConfig);
         try {
             await connection.standby();
         } finally {

--- a/src/cli/commands/start-id.ts
+++ b/src/cli/commands/start-id.ts
@@ -15,7 +15,7 @@ export default class extends Command {
         deviceSpec: DeviceOptions,
     ) {
         const device = await deviceSpec.findDevice();
-        const connection = await device.openConnection();
+        const connection = await device.openConnection(deviceSpec.connectionConfig);
         try {
             await connection.startTitleId(titleId);
         } finally {

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -11,7 +11,7 @@ import { IDiscoveredDevice, IDiscoveryConfig, INetworkConfig } from "../discover
 import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
 import { MimCredentialRequester } from "../credentials/mim-requester";
 import { DiskCredentialsStorage } from "../credentials/disk-storage";
-import { IDevice } from "../device/model";
+import { IConnectionConfig, IDevice } from "../device/model";
 import { RootManagingCredentialRequester } from "../credentials/root-managing";
 
 import { SudoCliProxy } from "./cli-proxy";
@@ -19,6 +19,7 @@ import { RootProxyDevice } from "./root-proxy-device";
 import { IInputOutput } from "./io";
 import { PinAcceptingDevice } from "./pin-accepting-device";
 import { RejectingCredentialRequester } from "../credentials/rejecting-requester";
+import { CliPassCode } from "./pass-code";
 
 export class InputOutputOptions extends Options implements IInputOutput {
     /* eslint-disable no-console */
@@ -99,6 +100,13 @@ export class DeviceOptions extends DiscoveryOptions {
     public credentialsPath?: string;
 
     @option({
+        name: "pass-code",
+        flag: "p",
+        description: "Your numeric passcode, or a string of key names",
+    })
+    public passCode?: CliPassCode;
+
+    @option({
         name: "ip",
         description: "Select a specific device by IP",
     })
@@ -124,7 +132,7 @@ export class DeviceOptions extends DiscoveryOptions {
         const { description, predicate } = this.configurePending();
 
         const networkConfig: INetworkConfig = {
-            // TODO
+            ...this.connectionConfig.network,
         };
 
         const args = process.argv;
@@ -177,6 +185,18 @@ export class DeviceOptions extends DiscoveryOptions {
                 currentUserId: process.getuid(),
             },
         );
+    }
+
+    public get connectionConfig(): IConnectionConfig {
+        return {
+            network: {
+                // TODO network config
+            },
+
+            login: {
+                passCode: this.passCode?.value,
+            },
+        };
     }
 
     private configurePending() {

--- a/src/cli/pass-code.ts
+++ b/src/cli/pass-code.ts
@@ -1,0 +1,20 @@
+import { ExpectedError } from "clime";
+import { parsePassCodeString } from "../credentials/pass-code";
+
+export class CliPassCode {
+    public static cast(input: string) {
+        try {
+            return parsePassCodeString(input);
+        } catch (e) {
+            if (e instanceof Error) {
+                throw new ExpectedError(e.message);
+            } else {
+                throw new ExpectedError(`${e}`);
+            }
+        }
+    }
+
+    constructor(
+        public readonly value: string,
+    ) {}
+}

--- a/src/credentials/pass-code.ts
+++ b/src/credentials/pass-code.ts
@@ -1,0 +1,67 @@
+export enum PassCodeKey {
+    Left = 1,
+    Up = 2,
+    Right = 3,
+    Down = 4,
+    R1 = 5,
+    R2 = 6,
+    L1 = 7,
+    L2 = 8,
+    Triangle = 9,
+    Square = 0,
+}
+
+const PASSCODE_LENGTH = 8;
+
+const nameToKey = Object.keys(PassCodeKey)
+    .reduce((m, key) => {
+        // eslint-disable-next-line no-param-reassign
+        m[key.toLowerCase()] = (PassCodeKey as any)[key] as PassCodeKey;
+        return m;
+    }, {} as {[name: string]: PassCodeKey});
+
+/**
+ * Given a sequence of passcode keys, convert them into the
+ * actual passcode numerical string value for use in ILoginConfig
+ */
+export function parsePassCodeKeys(...keys: PassCodeKey[]): string {
+    if (keys.length !== PASSCODE_LENGTH) {
+        throw new Error(`Passcode must have length ${PASSCODE_LENGTH}`);
+    }
+
+    let result = "";
+
+    for (const key of keys) {
+        result += key;
+    }
+
+    return result;
+}
+
+/**
+ * Given a raw value, which may either be a string of PassCodeKey names
+ * or a literal passcode string, return the validated passcode string
+ * value, for use in ILoginConfig.
+ */
+export function parsePassCodeString(input: string) {
+    if (/^[0-9]+$/.test(input)) {
+        if (input.length !== PASSCODE_LENGTH) {
+            throw new Error(`Passcode must be ${PASSCODE_LENGTH} numbers`);
+        }
+
+        return input;
+    }
+
+    const keys: PassCodeKey[] = [];
+    const inputParts = input.split(/[ ]+/);
+    for (const part of inputParts) {
+        const key = nameToKey[part.toLowerCase()];
+        if (key === undefined) {
+            throw new Error(`No such passcode key: ${part}`);
+        }
+
+        keys.push(key);
+    }
+
+    return parsePassCodeKeys(...keys);
+}

--- a/test/credentials/pass-code-test.ts
+++ b/test/credentials/pass-code-test.ts
@@ -1,0 +1,29 @@
+import * as chai from "chai";
+import { expect } from "chai";
+import { parsePassCodeString } from "../../src/credentials/pass-code";
+
+chai.should();
+
+describe("parsePassCodeString", () => {
+    it("accepts a valid numeric passcode", () => {
+        parsePassCodeString("01234567")
+            .should.equal("01234567");
+    });
+
+    it("accepts a valid key-based passcode", () => {
+        parsePassCodeString("square up up down down left right triangle")
+            .should.equal("02244139");
+    });
+
+    it("validates numeric length", () => {
+        expect(() => {
+            parsePassCodeString("0123");
+        }).to.throw(/must be/);
+    });
+
+    it("validates key-based length", () => {
+        expect(() => {
+            parsePassCodeString("up up down down");
+        }).to.throw(/must have length/);
+    });
+});


### PR DESCRIPTION
The API doesn't directly support passing passcode keys, but it
does provide tools transforming them into the passcode value, which
seems reasonable. We even provide a typesafe enum to use!
