### PR TITLE
Add flag for specifying "machine-friendly output"

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -30,6 +30,13 @@ export class InputOutputOptions extends Options implements IInputOutput {
     })
     public enableDebug = false;
 
+    @option({
+        name: "machine-friendly",
+        description: "Enable machine-friendly output",
+        toggle: true,
+    })
+    public machineFriendly = false;
+
     public logError(error: any) {
         console.error(error);
     }
@@ -43,6 +50,8 @@ export class InputOutputOptions extends Options implements IInputOutput {
     public logResult(result: any) {
         if (typeof result === "string") {
             console.log(result);
+        } else if (this.machineFriendly) {
+            console.log(JSON.stringify(result));
         } else {
             console.log(JSON.stringify(result, null, 2));
         }


### PR DESCRIPTION
We already only print "info" messages on stderr, but this will
additionally skip pretty-printing JSON results to ensure that
all printed JSON objects are 1-per-line
