### PR TITLE
Improve packet parsing

### DIFF
--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,9 +1,13 @@
+import _debug from "debug";
+
 import { IDeviceSocket } from "./socket/model";
 import {
     OskActionType, OskCommand, OskFlags, OskInputType,
 } from "./socket/osk";
 import { OskChangeStringPacket } from "./socket/packets/outgoing/osk-change-string";
 import { OskControlPacket } from "./socket/packets/outgoing/osk-control";
+
+const debug = _debug("playground:keyboard");
 
 /**
  * Represents an active on-screen keyboard control session
@@ -51,6 +55,7 @@ export class OnScreenKeyboard {
     ) {
         this.ensureValid();
 
+        debug("setting text:", text);
         await this.socket.send(new OskChangeStringPacket(
             text,
             { caretIndex },
@@ -68,6 +73,7 @@ export class OnScreenKeyboard {
         this.isValid = false;
 
         // give the device some time to process before we disconnect
+        debug("keep socket alive after submitting");
         this.socket.requestKeepAlive(450);
     }
 

--- a/src/socket/model.ts
+++ b/src/socket/model.ts
@@ -18,6 +18,7 @@ export interface IPacket {
 }
 
 export interface IPacketCodec {
+    paddingSize?: number;
     encode(packet: Buffer): Buffer;
     decode(packet: Buffer): Buffer;
 }
@@ -41,8 +42,8 @@ export enum PacketReadState {
  * overflow can be retrieved from `remainder()`
  */
 export interface IPacketReader {
-    read(codec: IPacketCodec, data: Buffer): PacketReadState;
-    get(codec: IPacketCodec): IPacket;
+    read(data: Buffer, paddingSize?: number): PacketReadState;
+    get(): IPacket;
     remainder(): Buffer | undefined;
 }
 

--- a/src/socket/packets/incoming/osk-start-result.ts
+++ b/src/socket/packets/incoming/osk-start-result.ts
@@ -25,19 +25,8 @@ export class OskStartResultPacket extends IncomingResultPacket {
         super(data);
 
         this.oskType = data.readInt32LE(12);
-
-        let lengthPosition = 16;
-        let stringPosition = 20;
-        if (data.length > 36) {
-            // TODO: for some reason, the way we decode it gives an extra
-            // 16 bytes of garbage here. We should really figure out why
-            // that's happening ... and fix it
-            lengthPosition += 16;
-            stringPosition += 16;
-        }
-
-        this.maxLength = data.readInt32LE(lengthPosition);
-        this.initialContent = data.toString("UTF-16LE", stringPosition);
+        this.maxLength = data.readInt32LE(16);
+        this.initialContent = data.toString("UTF-16LE", 20);
     }
 
     public get actionType() {

--- a/src/socket/proc/open-keyboard.ts
+++ b/src/socket/proc/open-keyboard.ts
@@ -1,9 +1,13 @@
+import _debug from "debug";
+
 import { OnScreenKeyboard } from "../../keyboard";
 import { performRpc } from "../helpers";
 import { IDeviceProc, IDeviceSocket } from "../model";
 import { OskStartResultPacket } from "../packets/incoming/osk-start-result";
 import { OskStartPacket } from "../packets/outgoing/osk-start";
 import { PacketType } from "../packets/types";
+
+const debug = _debug("playground:socket:OpenKeyboardProc");
 
 export class OpenKeyboardProc implements IDeviceProc<OnScreenKeyboard> {
     public async perform(socket: IDeviceSocket) {
@@ -13,6 +17,7 @@ export class OpenKeyboardProc implements IDeviceProc<OnScreenKeyboard> {
             PacketType.OskStartResult,
         );
 
+        debug("Opened keyboard! result = ", result);
         return new OnScreenKeyboard(
             socket,
             result.maxLength,

--- a/src/socket/protocol/v1.ts
+++ b/src/socket/protocol/v1.ts
@@ -4,7 +4,6 @@ import {
     IDeviceProtocol,
     IDeviceSocket,
     IPacket,
-    IPacketCodec,
     IPacketReader,
     PacketReadState,
 } from "../model";
@@ -37,13 +36,12 @@ const debug = _debug("playground:packets:v1");
 export class PacketReaderV1 implements IPacketReader {
     private readonly lengthDelimiter = new LengthDelimitedBufferReader();
 
-    public read(codec: IPacketCodec, data: Buffer): PacketReadState {
-        return this.lengthDelimiter.read(codec, data);
+    public read(data: Buffer, paddingSize?: number): PacketReadState {
+        return this.lengthDelimiter.read(data, paddingSize);
     }
 
-    public get(codec: IPacketCodec): IPacket {
-        const original = this.lengthDelimiter.get();
-        const buf = codec.decode(original);
+    public get(): IPacket {
+        const buf = this.lengthDelimiter.get();
         const type = buf.readInt32LE(PACKET_TYPE_OFFSET);
         const Constructor = packets[type];
         if (!Constructor) {

--- a/src/socket/tcp.ts
+++ b/src/socket/tcp.ts
@@ -136,7 +136,7 @@ export class TcpDeviceSocket implements IDeviceSocket {
     public setCodec(codec: IPacketCodec) {
         debug("switch to codec:", codec);
         this.codec = codec;
-        this.processor.codec = codec;
+        this.processor.setCodec(codec);
     }
 
     public async close() {

--- a/test/socket/base-test.ts
+++ b/test/socket/base-test.ts
@@ -5,7 +5,6 @@ import { BufferPacketProcessor } from "../../src/socket/base";
 import {
     IDeviceProtocol,
     IPacket,
-    IPacketCodec,
     IPacketReader,
     PacketReadState,
     PlaintextCodec,
@@ -19,13 +18,12 @@ chai.should();
 class FakePacketReader implements IPacketReader {
     private readonly lengthDelimiter = new LengthDelimitedBufferReader();
 
-    public read(codec: IPacketCodec, data: Buffer): PacketReadState {
-        return this.lengthDelimiter.read(codec, data);
+    public read(data: Buffer): PacketReadState {
+        return this.lengthDelimiter.read(data);
     }
 
-    public get(codec: IPacketCodec): IPacket {
-        const original = this.lengthDelimiter.get();
-        const buffer = codec.decode(original);
+    public get(): IPacket {
+        const buffer = this.lengthDelimiter.get();
         return {
             type: buffer.readInt32LE(4),
             toBuffer() { return buffer; },

--- a/test/socket/protocol/v1-test.ts
+++ b/test/socket/protocol/v1-test.ts
@@ -1,6 +1,6 @@
 import * as chai from "chai";
 
-import { IPacketReader, PacketReadState, PlaintextCodec } from "../../../src/socket/model";
+import { IPacketReader, PacketReadState } from "../../../src/socket/model";
 import { IncomingPacket } from "../../../src/socket/packets/base";
 import { PacketBuilder } from "../../../src/socket/packets/builder";
 import { DeviceProtocolV1 } from "../../../src/socket/protocol/v1";
@@ -16,12 +16,11 @@ describe("PacketReaderV1", () => {
 
     it("gracefully handles unsupported packets", () => {
         reader.read(
-            PlaintextCodec,
             new PacketBuilder(8)
                 .writeInt(-9001)
                 .build(),
         ).should.equal(PacketReadState.DONE);
 
-        reader.get(PlaintextCodec).should.be.instanceOf(IncomingPacket);
+        reader.get().should.be.instanceOf(IncomingPacket);
     });
 });

--- a/test/socket/util.ts
+++ b/test/socket/util.ts
@@ -11,7 +11,6 @@ import {
     IDeviceSocket,
     IPacket,
     IPacketCodec,
-    PlaintextCodec,
 } from "../../src/socket/model";
 import { DeviceProtocolV1 } from "../../src/socket/protocol/v1";
 
@@ -46,8 +45,8 @@ export class FakeSocket implements IDeviceSocket {
 
             try {
                 // try a more realistic parsing
-                reader.read(PlaintextCodec, packet.toBuffer());
-                yield reader.get(PlaintextCodec);
+                reader.read(packet.toBuffer());
+                yield reader.get();
             } catch (e) {
                 // packet doesn't support toBuffer...
                 yield packet;


### PR DESCRIPTION
> Decipher in padded chunks of 16; present decoded stream to parsers

The chunking seems to be how the actual code works; recreating the
decipher for every packet was incorrect. OSK still doesn't seem to work
for some reason, but that's (hopefully) a separate issue...
